### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -17,7 +17,7 @@ const fieldFunction = (() => {
           previous[current] = value;
           return previous[current];
         }
-        if (previous[current]) {
+        if (previous[current] && !isPrototypePolluted(current)) {
           return previous[current];
         }
         previous[current] = {};
@@ -26,6 +26,8 @@ const fieldFunction = (() => {
   
       return result;
     };
+
+    const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key);
   
     return {
       set


### PR DESCRIPTION
### :bar_chart: Metadata *

`sgt-fields` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-sgt-fields

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var sgtFields = require("sgt-fields")
var obj = {}
console.log("Before : " + {}.polluted);
sgtFields.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i sgt-fields # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102844639-d86c6200-4431-11eb-94d5-89374da231cc.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
